### PR TITLE
Gemfile: clean, move better errors to production, add did_you_mean

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,26 +4,13 @@ source 'https://rubygems.org'
 gem 'rails', '4.2.0'
 
 gem 'bourbon'
-# Use sqlite3 as the database for Active Record
-# Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
-# Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 1.3.0'
-# Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.1.0'
-# See https://github.com/sstephenson/execjs#readme for more supported runtimes
-# gem 'therubyracer', platforms: :ruby
-
-# Use jquery as the JavaScript library
 gem 'jquery-rails'
-# Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
 gem 'turbolinks'
 gem 'bootstrap-sass', '3.2.0.0'
-# Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.0'
-
-gem 'better_errors'
-# bundle exec rake doc:rails generates the API under doc/api.
 gem 'sdoc', '~> 0.4.0', group: :doc
 
 # Use ActiveModel has_secure_password
@@ -35,16 +22,24 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 
+group :development do
+  # NOTE: It is critical you put better_errors in the development section.
+  # Do NOT run better_errors in production, or on Internet facing hosts.
+  gem "better_errors"
+  gem "binding_of_caller"
+end
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'
-
   gem 'sqlite3'
   # Access an IRB console on exception pages or by using <%= console %> in views
   gem 'web-console', '~> 2.0'
-
-  # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
+
+  # With it, whenever you get NoMethodError or NameError, it'll automatically
+  # look for what you really wanted to call and tell it to you.
+  gem 'did_you_mean', '~> 0.9.6'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,12 +64,15 @@ GEM
     columnize (0.9.0)
     debug_inspector (0.0.2)
     debugger-linecache (1.2.0)
+    did_you_mean (0.9.6)
+      interception
     erubis (2.7.0)
     execjs (2.2.2)
     globalid (0.3.0)
       activesupport (>= 4.1.0)
     hike (1.2.3)
     i18n (0.7.0)
+    interception (0.5)
     jbuilder (2.2.6)
       activesupport (>= 3.0.0, < 5)
       multi_json (~> 1.2)
@@ -167,10 +170,12 @@ PLATFORMS
 
 DEPENDENCIES
   better_errors
+  binding_of_caller
   bootstrap-sass (= 3.2.0.0)
   bourbon
   byebug
   coffee-rails (~> 4.1.0)
+  did_you_mean (~> 0.9.6)
   jbuilder (~> 2.0)
   jquery-rails
   pg (= 0.18.1)


### PR DESCRIPTION
According to the creators of better_errors, the gem should always be in the development group only. I also added two gems that make debugging slightly easier.
